### PR TITLE
Adopt components name to the new version of Vuex ORM

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/graphql": "^0.12.3",
     "@types/inflection": "^1.5.28",
     "@types/lodash-es": "^4.17.0",
-    "@vuex-orm/core": "^0.25.4",
+    "@vuex-orm/core": "^0.25.5",
     "apollo-cache-inmemory": "^1.1.7",
     "apollo-client": "^2.2.2",
     "apollo-link": "^1.2.0",

--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -3,7 +3,7 @@ import Context from '../common/context';
 import { Store } from '../orm/store';
 import { Arguments, Data, DispatchFunction } from '../support/interfaces';
 import Model from '../orm/model';
-import State from '@vuex-orm/core/lib/modules/State';
+import RootState from '@vuex-orm/core/lib/modules/contracts/RootState';
 import Transformer from '../graphql/transformer';
 import NameGenerator from '../graphql/name-generator';
 import Schema from '../graphql/schema';
@@ -63,10 +63,10 @@ export default class Action {
 
   /**
    * Convenience method to get the model from the state.
-   * @param {State} state Vuex state
+   * @param {RootState} state Vuex state
    * @returns {Model}
    */
-  protected static getModelFromState (state: State): Model {
+  protected static getModelFromState (state: RootState): Model {
     return Context.getInstance().getModel(state.$name);
   }
 

--- a/src/support/interfaces.ts
+++ b/src/support/interfaces.ts
@@ -1,6 +1,6 @@
 import ORMModel from '@vuex-orm/core/lib/model/Model';
 import Database from '@vuex-orm/core/lib/database/Database';
-import State from '@vuex-orm/core/lib/modules/State';
+import RootState from '@vuex-orm/core/lib/modules/contracts/RootState';
 import { ApolloLink } from 'apollo-link';
 
 export type DispatchFunction = (action: string, data: Data) => Promise<any>;
@@ -22,7 +22,7 @@ export interface ActionParams {
   getters: any;
   rootGetters: any;
   rootState: any;
-  state: State;
+  state: RootState;
   filter?: Filter;
   id?: number;
   data?: Data;

--- a/src/vuex-orm-graphql.ts
+++ b/src/vuex-orm-graphql.ts
@@ -28,15 +28,15 @@ export default class VuexORMGraphQL {
   private static setupActions () {
     const context = Context.getInstance();
 
-    context.components.rootActions.simpleQuery = SimpleQuery.call.bind(SimpleQuery);
-    context.components.rootActions.simpleMutation = SimpleMutation.call.bind(SimpleMutation);
+    context.components.RootActions.simpleQuery = SimpleQuery.call.bind(SimpleQuery);
+    context.components.RootActions.simpleMutation = SimpleMutation.call.bind(SimpleMutation);
 
-    context.components.subActions.fetch = Fetch.call.bind(Fetch);
-    context.components.subActions.persist = Persist.call.bind(Persist);
-    context.components.subActions.push = Push.call.bind(Push);
-    context.components.subActions.destroy = Destroy.call.bind(Destroy);
-    context.components.subActions.mutate = Mutate.call.bind(Mutate);
-    context.components.subActions.query = Query.call.bind(Query);
+    context.components.Actions.fetch = Fetch.call.bind(Fetch);
+    context.components.Actions.persist = Persist.call.bind(Persist);
+    context.components.Actions.push = Push.call.bind(Push);
+    context.components.Actions.destroy = Destroy.call.bind(Destroy);
+    context.components.Actions.mutate = Mutate.call.bind(Mutate);
+    context.components.Actions.query = Query.call.bind(Query);
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,9 +185,9 @@
     source-map "^0.5.6"
     vue-template-es2015-compiler "^1.6.0"
 
-"@vuex-orm/core@^0.25.4":
-  version "0.25.4"
-  resolved "https://registry.yarnpkg.com/@vuex-orm/core/-/core-0.25.4.tgz#0609e0df8a2ab2b614d53b8ce25e2c2bd562d0d3"
+"@vuex-orm/core@^0.25.5":
+  version "0.25.5"
+  resolved "https://registry.yarnpkg.com/@vuex-orm/core/-/core-0.25.5.tgz#ebdcfbbdb19195fff76309c1a8d4c1a708a23b38"
 
 "@webassemblyjs/ast@1.4.3":
   version "1.4.3"


### PR DESCRIPTION
Hi! Currently I'm organizing the modules at Vuex ORM and willing to change its names. The changes are;

```
subGetters -> Getters
subActions -> Actions
rootGetters -> RootGetters
rootActions -> RootActions
mutations -> RootMutations
```

I think these are the only place we need to change? Sorry for taking your time but could you take a look?

Please do not merge this PR until Vuex ORM changes is applied! I'll let you know when it's ready!